### PR TITLE
fixes bug wherein modules that have been subverted multiple times lose their original reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,9 @@ RequireSubvert.prototype.require = function(name) {
 }
 
 RequireSubvert.prototype.cleanUp = function() {
+  // if we don't do it backwards, modules that have been subverted multiple
+  // times will not get their originals properly.
+  this._replacements.reverse();
   this._replacements.forEach(function (replacement) {
     require.cache[replacement.path].exports = replacement.original
   })


### PR DESCRIPTION
Hi,

I had a problem wherein I was doing this:

``` js
describe('foo', function() {
  var m;

  beforeEach(function() {
    rs.subvert('bar', function() { return 1; });
    m = rs.require('m');
  });

  afterEach(function() {
    rs.cleanUp();
  });

  describe('baz', function() {
    it('should subvert bar differently', function() {
       rs.subvert('bar', function() { return 2; });
       m = rs.require('m');
       // test
    });
  });
});
```

And noticed that in another test against `bar` itself, if I did `require('bar')` I would receive second stub function instead of the original.

Changing the order in which `cleanUp()` restores seems to correct the issue.

Summary of changes
- reversed `_replacements` array before restoring.
- added a blank line to end of file.  thanks, editor.

Thank you.  I like this better than other similar modules I've found; very simple and does what it says on the tin.
